### PR TITLE
Fix mastodon link

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -3,7 +3,7 @@ title: "Julia Stewart Lowndes, PhD"
 image: "images/lowndes-portrait-square.jpeg"
 links:
   - label: Mastodon
-    url: "https://fosstodon.org/@juliesquid"
+    url: "https://fosstodon.org/\\@juliesquid"
   - label: GitHub
     url: "https://github.com/jules32"
   - label: ORCID


### PR DESCRIPTION
I noticed that the URL to your mastodon profile didn't work:

![image](https://github.com/user-attachments/assets/a2181045-34a7-47d3-af29-ef08192c0198)

I fixed it following the workaround in https://github.com/seankross/postcards/issues/57#issuecomment-1314460533